### PR TITLE
Added the functionality as stated in #10 at the /compare api endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Start by configuring and launching the project on your local machine after follo
 Before you begin, ensure you have the following prerequisites installed on your system / local machines.
 
 - Python (Python 3.10.7 preferred)
+- Visual Studio (for C++ build tools)
 - Knowledge of Machine Learning models and how to use model in the application.
 - FastAPI Knowledge
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ python-dotenv==1.0.0
 python-multipart==0.0.6
 tensorflow==2.13.0
 uvicorn==0.23.2
+opencv-python==4.8.1.78
+face-recognition==1.3.0

--- a/src/app.py
+++ b/src/app.py
@@ -1,7 +1,7 @@
 import uvicorn
 from dotenv import load_dotenv
 from fastapi import FastAPI, File, UploadFile
-from .components.serve_model import predict, read_imagefile
+from .components.serve_model import predict, read_imagefile, compare_two_faces
 import os
 
 load_dotenv(".env")
@@ -22,6 +22,18 @@ async def predict_api(file: UploadFile = File(...)):
     prediction = predict(image)
 
     return prediction
+
+@app.post("/compare")
+async def compare_api(file1: UploadFile = File(...), file2: UploadFile = File(...)):
+    extension1 = file1.filename.split(".")[-1] in ("jpg", "jpeg", "png")
+    extension2 = file2.filename.split(".")[-1] in ("jpg", "jpeg", "png")
+    if not extension1 or not extension2:
+        return "Image must be jpg or png format!"
+    image1 = read_imagefile(await file1.read())
+    image2 = read_imagefile(await file2.read())
+    result = compare_two_faces(image1, image2)
+
+    return result
 
 
 if __name__ == "__main__":

--- a/src/components/serve_model.py
+++ b/src/components/serve_model.py
@@ -2,8 +2,11 @@ from io import BytesIO
 
 import numpy as np
 import tensorflow as tf
+import cv2
+import face_recognition
+from tensorflow import keras
 from PIL import Image
-from tensorflow.keras.applications.imagenet_utils import decode_predictions
+from keras.applications.imagenet_utils import decode_predictions
 
 model = None
 
@@ -39,3 +42,20 @@ def predict(image: Image.Image):
 def read_imagefile(file) -> Image.Image:
     image = Image.open(BytesIO(file))
     return image
+
+def compare_two_faces(image1: Image.Image, image2: Image.Image):
+    image1 = np.asarray(image1.resize((224, 224)))[..., :3]
+    image2 = np.asarray(image2.resize((224, 224)))[..., :3]
+
+    face1_encodings = face_recognition.face_encodings(image1)
+    face2_encodings = face_recognition.face_encodings(image2)
+
+    if not face1_encodings or not face2_encodings:
+        return "No face detected in one of the images"
+
+    face1 = face1_encodings[0]
+    face2 = face2_encodings[0]
+
+    result = face_recognition.compare_faces([face1], face2)
+
+    return result[0] and "Same person" or "Not same person"


### PR DESCRIPTION
If any of the both images doesn't contain any face(s), it returns appropriate error and doesn't crashes! I have tested the endpoint with two images of The Prime Minister of India and it does identifies both as "Same person".

![image](https://github.com/thecodermaniac/FaceApi/assets/84619413/e5040323-0447-45f6-93fb-74f877bf5de8)
